### PR TITLE
去掉`contentContainerProps`的绝对定位以自适应高度

### DIFF
--- a/src/ScrollView.js
+++ b/src/ScrollView.js
@@ -184,7 +184,7 @@ export default class ScrollView extends React.Component {
     };
     const contentContainerProps = {
       ref: INNERVIEW,
-      style: assign({}, { position: 'absolute', minWidth: '100%' }, contentContainerStyle),
+      style: assign({}, { minWidth: '100%' }, contentContainerStyle),
       className: classNames({
         [`${preCls}-scrollview-content`]: true,
         [listPrefixCls]: !!listPrefixCls,


### PR DESCRIPTION
去掉`contentContainerProps`的绝对定位以自适应高度