### PR TITLE
onTouchEnd handler trim the whitespace infront of props.prefixcls-qsb…

### DIFF
--- a/src/Indexed.js
+++ b/src/Indexed.js
@@ -125,7 +125,7 @@ export default class IndexedList extends React.Component {
     }
     document.removeEventListener('touchmove', this._disableParent, false);
     document.body.className = document.body.className.replace(
-      new RegExp(`${this.props.prefixCls}-qsb-moving`, 'g'), '');
+      new RegExp(`\\s*${this.props.prefixCls}-qsb-moving`, 'g'), '');
     this.updateIndicator(this._target, true);
     this._target = null;
   }


### PR DESCRIPTION
<img width="313" alt="2017-03-09 3 47 47" src="https://cloud.githubusercontent.com/assets/12448145/23740713/cd6e252c-04df-11e7-98e1-e86b0dcd4c6b.png">
每次 touch 都会多一个 空格