### PR TITLE
removes overflow auto

### DIFF
--- a/src/ScrollView.js
+++ b/src/ScrollView.js
@@ -29,7 +29,6 @@ const propTypes = {
 const styles = {
   base: {
     position: 'relative',
-    overflow: 'auto',
     WebkitOverflowScrolling: 'touch',
     flex: 1,
   },


### PR DESCRIPTION
ran into a weird bug where listview was present in the DOM but there was nothing being printed on the screen, some digging and overflow was found to be the issue, this fixes it.

removes `overflow: auto` property that fixes the items in DOM but not rendering bug.