### PR TITLE
fixed null ref.

### DIFF
--- a/src/ScrollView.js
+++ b/src/ScrollView.js
@@ -127,7 +127,7 @@ export default class ScrollView extends React.Component {
     const preCls = prefixCls || listViewPrefixCls || '';
 
     const containerProps = {
-      ref: el => this.ScrollViewRef = el,
+      ref: el => this.ScrollViewRef = el || this.ScrollViewRef,
       style: { ...(useBodyScroll ? {} : styleBase), ...style },
       className: classNames(className, `${preCls}-scrollview`),
     };


### PR DESCRIPTION
at react 15.6.2, ref will be called with params null.
And this will Caused another branch render in PullToRefresh。

like：
if (getScrollContainer()) {
      return renderRefresh(`${prefixCls}-content ${prefixCls}-${direction}`);
    }
    return (
      <div
        ref={el => this.containerRef = el}
        className={classNames(className, prefixCls, `${prefixCls}-${direction}`)}
        {...restProps}
      >
        {renderRefresh(`${prefixCls}-content`)}
      </div>
    );

finally prevent pullDown in special case。